### PR TITLE
Remove 'Under construction' subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
 <body>
     <h1 class="title">Alicante Frontend</h1>
     <img class="logo" src="src/img/alicante-frontend-logo.svg" alt="Alicante Frontend Logo" />
-    <p class="under-construction">En construcción</p>
     <ul class="list">
         <li>
             <a target="_blank" href="https://www.meetup.com/es-ES/Alicante-Frontend">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -68,11 +68,7 @@ footer .footer-right-link {
     height: auto;
     max-width: 95%;
     width: 700px;
-}
-
-.under-construction {
-    font-size: 0.9em;
-    margin-bottom: 3em;
+    margin-bottom: 4rem;
 }
 
 .list {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -68,7 +68,7 @@ footer .footer-right-link {
     height: auto;
     max-width: 95%;
     width: 700px;
-    margin-bottom: 4rem;
+    margin-bottom: 4.5rem;
 }
 
 .list {


### PR DESCRIPTION
The website has  "under construction" subtitle  a lot of time without notable changes.  
Can not we think that the web is simple, instead of showing that it's under construction? 
Do you know what i mean? 🍶 

Result: 
![result](https://user-images.githubusercontent.com/6113535/47269140-23407580-d55a-11e8-8aef-e32f514a172d.PNG)
