### PR TITLE
feat: add Instagram, LinkedIn, GitHub and Telegram links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -67,11 +67,11 @@ const links = [
 			Si quieres aprender y compartir sobre desarrollo web orientado al Frontend has llegado al sitio correcto.
 		</p>
 
-		<ul class="grid w-full max-w-[1200px] grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5 lg:gap-4 animate-fade-up [animation-delay:300ms] list-none p-0">
+		<ul class="flex flex-col sm:flex-row flex-wrap justify-center w-full max-w-[1200px] gap-4 animate-fade-up [animation-delay:300ms] list-none p-0">
 			{links.map(({ href, icon, label, disabled }) => (
 				<li>
 					{disabled ? (
-						<div class="relative flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-dashed border-brand/15 bg-white/40 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink/40">
+						<div class="sm:w-56 relative flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-dashed border-brand/15 bg-white/40 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink/40">
 							<Icon name={icon} class="h-8 w-8 text-brand/30" />
 							<span class="whitespace-nowrap">{label}</span>
 							<span class="absolute bottom-4 text-xs font-normal text-brand/50">Próximamente</span>
@@ -81,7 +81,7 @@ const links = [
 							target="_blank"
 							rel="noopener noreferrer"
 							href={href}
-							class="group flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-brand/15 bg-white/80 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink shadow-[0_12px_30px_rgba(24,133,214,0.1)] backdrop-blur-md transition-all duration-300 hover:-translate-y-1.5 hover:border-brand/40 hover:bg-white hover:shadow-[0_22px_45px_rgba(24,133,214,0.22)]"
+							class="sm:w-56 group flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-brand/15 bg-white/80 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink shadow-[0_12px_30px_rgba(24,133,214,0.1)] backdrop-blur-md transition-all duration-300 hover:-translate-y-1.5 hover:border-brand/40 hover:bg-white hover:shadow-[0_22px_45px_rgba(24,133,214,0.22)]"
 						>
 							<Icon name={icon} class="h-8 w-8 text-brand transition-transform duration-300 group-hover:scale-110 group-hover:-rotate-6" />
 							<span class="whitespace-nowrap">{label}</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,9 +24,29 @@ const links = [
 		label: 'Síguenos en X',
 	},
 	{
+		href: 'https://www.instagram.com/alicantefrontend/',
+		icon: 'simple-icons:instagram',
+		label: 'Síguenos en Instagram',
+	},
+	{
+		href: 'https://www.linkedin.com/company/alicante-frontend/',
+		icon: 'simple-icons:linkedin',
+		label: 'Síguenos en LinkedIn',
+	},
+	{
 		href: 'https://www.youtube.com/AlicanteFrontend',
 		icon: 'lucide:youtube',
 		label: 'Suscríbete al canal',
+	},
+	{
+		href: 'https://github.com/AlicanteFrontend',
+		icon: 'simple-icons:github',
+		label: 'GitHub',
+	},
+	{
+		icon: 'simple-icons:telegram',
+		label: 'Telegram',
+		disabled: true,
 	},
 ];
 ---
@@ -48,17 +68,25 @@ const links = [
 		</p>
 
 		<ul class="grid w-full max-w-[1200px] grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5 lg:gap-4 animate-fade-up [animation-delay:300ms] list-none p-0">
-			{links.map(({ href, icon, label }) => (
+			{links.map(({ href, icon, label, disabled }) => (
 				<li>
-					<a
-						target="_blank"
-						rel="noopener noreferrer"
-						href={href}
-						class="group flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-brand/15 bg-white/80 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink shadow-[0_12px_30px_rgba(24,133,214,0.1)] backdrop-blur-md transition-all duration-300 hover:-translate-y-1.5 hover:border-brand/40 hover:bg-white hover:shadow-[0_22px_45px_rgba(24,133,214,0.22)]"
-					>
-						<Icon name={icon} class="h-8 w-8 text-brand transition-transform duration-300 group-hover:scale-110 group-hover:-rotate-6" />
-						<span class="whitespace-nowrap">{label}</span>
-					</a>
+					{disabled ? (
+						<div class="relative flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-dashed border-brand/15 bg-white/40 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink/40">
+							<Icon name={icon} class="h-8 w-8 text-brand/30" />
+							<span class="whitespace-nowrap">{label}</span>
+							<span class="absolute bottom-4 text-xs font-normal text-brand/50">Próximamente</span>
+						</div>
+					) : (
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href={href}
+							class="group flex min-h-[130px] flex-col items-center justify-center gap-2.5 border border-brand/15 bg-white/80 px-3 py-6 text-center text-[0.95rem] font-semibold text-ink shadow-[0_12px_30px_rgba(24,133,214,0.1)] backdrop-blur-md transition-all duration-300 hover:-translate-y-1.5 hover:border-brand/40 hover:bg-white hover:shadow-[0_22px_45px_rgba(24,133,214,0.22)]"
+						>
+							<Icon name={icon} class="h-8 w-8 text-brand transition-transform duration-300 group-hover:scale-110 group-hover:-rotate-6" />
+							<span class="whitespace-nowrap">{label}</span>
+						</a>
+					)}
 				</li>
 			))}
 		</ul>


### PR DESCRIPTION
## Summary

- Add Instagram, LinkedIn and GitHub link cards to the homepage
- Add Telegram as a disabled card with a "Próximamente" label (dashed border, muted colors)
- Cards flow naturally in the existing 5-column grid layout (5 + 4 on desktop)

## Screenshots

### Desktop (1280px)
<img width="1280" height="988" alt="image" src="https://github.com/user-attachments/assets/5550d2d3-fe4a-4bd0-a711-d0fda74fca42" />

### Mobile (390px)
<img width="390" height="2055" alt="image" src="https://github.com/user-attachments/assets/273e5205-4ab0-4c1d-a5a2-4ab0ce230a20" />

## Test plan

- [x] `pnpm build` completes without errors
- [x] Verified desktop layout (5 + 4 grid)
- [x] Verified tablet layout (2 columns)
- [x] Verified mobile layout (single column)
- [x] Telegram card shows disabled state with "Próximamente"
- [x] All new links point to correct URLs